### PR TITLE
Admin Page with Vacancy and Resume Moderation Features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@trpc/server": "^10.18.0",
         "bcrypt": "^5.1.0",
         "cookie": "^0.5.0",
+        "date-fns": "^2.30.0",
         "js-cookie": "^3.0.5",
         "jsonwebtoken": "^9.0.0",
         "next": "^13.2.4",
@@ -1683,6 +1684,21 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@trpc/server": "^10.18.0",
     "bcrypt": "^5.1.0",
     "cookie": "^0.5.0",
+    "date-fns": "^2.30.0",
     "js-cookie": "^3.0.5",
     "jsonwebtoken": "^9.0.0",
     "next": "^13.2.4",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,10 +82,11 @@ model Resume {
 }
 
 model Vacancy {
-    questionnaireId String        @unique
-    questionnaire   Questionnaire @relation(fields: [questionnaireId], references: [questionnaireId])
-    employerId      String
-    employer        Employer      @relation(fields: [employerId], references: [employerId])
+    questionnaireId  String           @unique
+    questionnaire    Questionnaire    @relation(fields: [questionnaireId], references: [questionnaireId])
+    employerId       String
+    employer         Employer         @relation(fields: [employerId], references: [employerId])
+    moderationStatus ModerationStatus @default(PENDING)
 
     specialty         String
     salary            String?

--- a/src/component/admin/adminNavigationMenu.tsx
+++ b/src/component/admin/adminNavigationMenu.tsx
@@ -1,0 +1,35 @@
+import { useRouter } from "next/router";
+import Link from "next/link";
+import { classNames } from "~/component/layout/elements/header";
+
+export function AdminNavigationMenu() {
+  const router = useRouter();
+  const isActivePage = (currentPage: string) => currentPage === router.pathname;
+
+  const navigation: { name: string; href: string }[] = [
+    { name: "Резюме кандидатів", href: "/admin/candidates" },
+    { name: "Вакансії компаній", href: "/admin/employer" },
+  ];
+
+  return (
+    <div className="flex space-x-4">
+      {navigation.map((item) => {
+        return (
+          <Link
+            key={item.name}
+            href={item.href}
+            className={classNames(
+              isActivePage(item.href)
+                ? "bg-gray-900 text-white"
+                : "hover:bg-gray-700 hover:text-white",
+              "rounded-md px-3 py-2 text-sm font-medium"
+            )}
+            aria-current={isActivePage(item.href) ? "page" : undefined}
+          >
+            {item.name}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/component/admin/moderation/moderateCandidate.tsx
+++ b/src/component/admin/moderation/moderateCandidate.tsx
@@ -1,0 +1,55 @@
+import { SelectModerationStatus } from "~/component/admin/moderation/selectModerationStatus";
+import React, { useState } from "react";
+import type { ModerationStatus } from "@prisma/client";
+import type { ParsedCandidate } from "~/pages/candidate/[candidate]";
+
+export function ModerateCandidate({
+  candidateData,
+}: {
+  candidateData: ParsedCandidate;
+}) {
+  const moderationStatus: ModerationStatus =
+    candidateData?.candidate?.questionnaires?.resume?.moderationStatus ||
+    "PENDING";
+  const questionnaireId =
+    candidateData?.candidate?.questionnaires?.questionnaireId;
+
+  const [selectedStatus, setSelectedStatus] =
+    useState<ModerationStatus>(moderationStatus);
+
+  function handleChangeStatus(moderationStatus: ModerationStatus) {
+    void updateModerationStatus(moderationStatus);
+  }
+
+  async function updateModerationStatus(
+    moderationStatus: ModerationStatus
+  ): Promise<void> {
+    try {
+      const response = await fetch("/api/candidate/updateModerationStatus", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          moderationStatus,
+          questionnaireId,
+        }),
+      });
+
+      if (response.ok) {
+        setSelectedStatus(moderationStatus);
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  return (
+    <>
+      <hr className="w-full border-gray-300" />
+      <strong className="py-4 text-lg font-semibold">Статус модерації:</strong>
+      <SelectModerationStatus
+        moderationStatus={selectedStatus}
+        handleChangeStatus={handleChangeStatus}
+      />
+    </>
+  );
+}

--- a/src/component/admin/moderation/moderateJob.tsx
+++ b/src/component/admin/moderation/moderateJob.tsx
@@ -1,0 +1,48 @@
+import { SelectModerationStatus } from "~/component/admin/moderation/selectModerationStatus";
+import React, { useState } from "react";
+import type { ModerationStatus } from "@prisma/client";
+import type { JobInformation } from "~/pages/job/[job]";
+
+export function ModerateJob({ jobInfo }: { jobInfo: JobInformation }) {
+  const moderationStatus = jobInfo.vacancy?.moderationStatus ?? "PENDING";
+  const questionnaireId = jobInfo.vacancy?.questionnaireId;
+
+  const [selectedStatus, setSelectedStatus] =
+    useState<ModerationStatus>(moderationStatus);
+
+  function handleChangeStatus(moderationStatus: ModerationStatus) {
+    void updateModerationStatus(moderationStatus);
+  }
+
+  async function updateModerationStatus(
+    moderationStatus: ModerationStatus
+  ): Promise<void> {
+    try {
+      const response = await fetch("/api/employer/updateModerationStatus", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          moderationStatus,
+          questionnaireId,
+        }),
+      });
+
+      if (response.ok) {
+        setSelectedStatus(moderationStatus);
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  return (
+    <>
+      <hr className="w-full border-gray-300" />
+      <strong className="py-4 text-lg font-semibold">Статус модерації:</strong>
+      <SelectModerationStatus
+        moderationStatus={selectedStatus}
+        handleChangeStatus={handleChangeStatus}
+      />
+    </>
+  );
+}

--- a/src/component/admin/moderation/selectModerationStatus.tsx
+++ b/src/component/admin/moderation/selectModerationStatus.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from "react";
+import { Fragment } from "react";
 import { Listbox, Transition } from "@headlessui/react";
 import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
 import type { ModerationStatus } from "@prisma/client";
@@ -11,44 +11,16 @@ const moderationStatuses: ModerationStatus[] = [
 
 export function SelectModerationStatus({
   moderationStatus,
-  questionnaireId,
+  handleChangeStatus,
 }: {
   moderationStatus: ModerationStatus;
-  questionnaireId: string;
+  handleChangeStatus: (moderationStatus: ModerationStatus) => void;
 }) {
-  const [selectedStatus, setSelectedStatus] =
-    useState<ModerationStatus>(moderationStatus);
-
-  function handleChangeStatus(moderationStatus: ModerationStatus) {
-    void updateModerationStatus(moderationStatus);
-  }
-
-  async function updateModerationStatus(
-    moderationStatus: ModerationStatus
-  ): Promise<void> {
-    try {
-      const response = await fetch("/api/candidate/updateModerationStatus", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          moderationStatus,
-          questionnaireId,
-        }),
-      });
-
-      if (response.ok) {
-        setSelectedStatus(moderationStatus);
-      }
-    } catch (e) {
-      console.log(e);
-    }
-  }
-
   return (
-    <Listbox value={selectedStatus} onChange={handleChangeStatus}>
+    <Listbox value={moderationStatus} onChange={handleChangeStatus}>
       <div className="relative mt-1">
         <Listbox.Button className="relative w-full cursor-default rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:text-sm">
-          <span className="block truncate">{selectedStatus}</span>
+          <span className="block truncate">{moderationStatus}</span>
           <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
             <ChevronUpDownIcon
               className="h-5 w-5 text-gray-400"

--- a/src/component/admin/selectModerationStatus.tsx
+++ b/src/component/admin/selectModerationStatus.tsx
@@ -1,0 +1,99 @@
+import { Fragment, useState } from "react";
+import { Listbox, Transition } from "@headlessui/react";
+import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
+import type { ModerationStatus } from "@prisma/client";
+
+const moderationStatuses: ModerationStatus[] = [
+  "ACCEPTED",
+  "PENDING",
+  "REJECTED",
+];
+
+export function SelectModerationStatus({
+  moderationStatus,
+  questionnaireId,
+}: {
+  moderationStatus: ModerationStatus;
+  questionnaireId: string;
+}) {
+  const [selectedStatus, setSelectedStatus] =
+    useState<ModerationStatus>(moderationStatus);
+
+  function handleChangeStatus(moderationStatus: ModerationStatus) {
+    void updateModerationStatus(moderationStatus);
+  }
+
+  async function updateModerationStatus(
+    moderationStatus: ModerationStatus
+  ): Promise<void> {
+    try {
+      const response = await fetch("/api/candidate/updateModerationStatus", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          moderationStatus,
+          questionnaireId,
+        }),
+      });
+
+      if (response.ok) {
+        setSelectedStatus(moderationStatus);
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  return (
+    <Listbox value={selectedStatus} onChange={handleChangeStatus}>
+      <div className="relative mt-1">
+        <Listbox.Button className="relative w-full cursor-default rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:text-sm">
+          <span className="block truncate">{selectedStatus}</span>
+          <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+            <ChevronUpDownIcon
+              className="h-5 w-5 text-gray-400"
+              aria-hidden="true"
+            />
+          </span>
+        </Listbox.Button>
+        <Transition
+          as={Fragment}
+          leave="transition ease-in duration-100"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <Listbox.Options className="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+            {moderationStatuses.map((moderationStatus, moderationId) => (
+              <Listbox.Option
+                key={moderationId}
+                className={({ active }) =>
+                  `relative cursor-default select-none py-2 pl-10 pr-4 ${
+                    active ? "bg-amber-100 text-amber-900" : "text-gray-900"
+                  }`
+                }
+                value={moderationStatus}
+              >
+                {({ selected }) => (
+                  <>
+                    <span
+                      className={`block truncate ${
+                        selected ? "font-medium" : "font-normal"
+                      }`}
+                    >
+                      {moderationStatus}
+                    </span>
+                    {selected ? (
+                      <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-amber-600">
+                        <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                      </span>
+                    ) : null}
+                  </>
+                )}
+              </Listbox.Option>
+            ))}
+          </Listbox.Options>
+        </Transition>
+      </div>
+    </Listbox>
+  );
+}

--- a/src/component/candidate/resumePreview.tsx
+++ b/src/component/candidate/resumePreview.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import type { ParsedCandidate } from "~/pages/candidates";
+
+export function CandidateResumePreview({
+  candidate,
+}: {
+  candidate: ParsedCandidate;
+}) {
+  return (
+    <div className="rounded-md border border-gray-300 p-4" key={candidate.id}>
+      <Link
+        href={`/candidate/${candidate.id}`}
+        className="mb-3 flex items-center"
+      >
+        <div>
+          <div className="font-bold text-blue-600  hover:text-blue-800">
+            {candidate.firstName} {candidate.lastName}
+          </div>
+          <div className="text-sm text-gray-500">
+            {candidate.candidate?.questionnaires?.resume?.specialty}
+          </div>
+        </div>
+      </Link>
+      {candidate.candidate?.questionnaires?.resume?.workExperience && (
+        <div className="mb-2">
+          <strong>Work Experience:</strong>{" "}
+          {candidate.candidate.questionnaires.resume.workExperience}
+        </div>
+      )}
+      {candidate.candidate?.questionnaires?.resume?.skills && (
+        <div className="mb-2">
+          <strong>Skills:</strong>{" "}
+          {candidate.candidate.questionnaires.resume.skills}
+        </div>
+      )}
+      {candidate.candidate?.questionnaires?.resume?.education && (
+        <div className="mb-2">
+          <strong>Education:</strong>{" "}
+          {candidate.candidate.questionnaires.resume.education}
+        </div>
+      )}
+      {candidate.candidate?.questionnaires?.resume?.foreignLanguages && (
+        <div className="mb-2">
+          <strong>Foreign Languages:</strong>{" "}
+          {candidate.candidate.questionnaires.resume.foreignLanguages}
+        </div>
+      )}
+      {candidate.candidate?.questionnaires?.resume?.interests && (
+        <div className="mb-2">
+          <strong>Interests:</strong>{" "}
+          {candidate.candidate.questionnaires.resume.interests}
+        </div>
+      )}
+      {candidate.candidate?.questionnaires?.resume?.achievements && (
+        <div className="mb-2">
+          <strong>Achievements:</strong>{" "}
+          {candidate.candidate.questionnaires.resume.achievements}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/component/employer/vacancyPreview.tsx
+++ b/src/component/employer/vacancyPreview.tsx
@@ -1,0 +1,53 @@
+import type { Vacancy } from "@prisma/client";
+import Link from "next/link";
+import { format } from "date-fns";
+
+export function VacancyPreview({ vacancy }: { vacancy: Vacancy }) {
+  return (
+    <div className="rounded-md border border-gray-300 p-4">
+      <Link href={`/job/${vacancy.questionnaireId}`}>
+        <div className="mb-3 flex items-center">
+          <div>
+            <div className="font-bold text-blue-600 hover:text-blue-800">
+              {vacancy.specialty}
+            </div>
+          </div>
+        </div>
+      </Link>
+      {vacancy.salary && (
+        <div className="mb-2">
+          <strong>Зарплата:</strong> ${vacancy.salary}
+        </div>
+      )}
+      {vacancy.duties && (
+        <div className="mb-2">
+          <strong>Обов&apos;язки:</strong> {vacancy.duties}
+        </div>
+      )}
+      {vacancy.requirements && (
+        <div className="mb-2">
+          <strong>Вимоги:</strong> {vacancy.requirements}
+        </div>
+      )}
+      {vacancy.conditions && (
+        <div className="mb-2">
+          <strong>Умови:</strong> {vacancy.conditions}
+        </div>
+      )}
+      {vacancy.workSchedule && (
+        <div className="mb-2">
+          <strong>Графік роботи:</strong> {vacancy.workSchedule}
+        </div>
+      )}
+      {vacancy.employment && (
+        <div className="mb-2">
+          <strong>Тип зайнятості:</strong> {vacancy.employment}
+        </div>
+      )}
+      <div className="mb-2">
+        <strong>Опубліковано:</strong>{" "}
+        {format(vacancy.dateOfPublication, "d MMMM yyyy, HH:mm")}
+      </div>
+    </div>
+  );
+}

--- a/src/component/questionnaire/renderQuestionnaireDetail.tsx
+++ b/src/component/questionnaire/renderQuestionnaireDetail.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export function renderQuestionnaireDetail(
+  title: string,
+  data: string | null | undefined
+) {
+  if (!data) return null;
+  return (
+    <div className="mb-4">
+      <strong className="text-lg font-semibold">{title}:</strong>
+      <p className="mt-2 text-gray-700">{data}</p>
+    </div>
+  );
+}

--- a/src/component/questionnaire/renderQuestionnaireInfo.tsx
+++ b/src/component/questionnaire/renderQuestionnaireInfo.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+export function renderQuestionnaireInfo(
+  title: string,
+  data: string | null | undefined,
+  href?: string | null
+) {
+  if (!data) return null;
+  return (
+    <div className="mb-4 flex items-center gap-2">
+      <strong className="text-lg font-semibold">{title}:</strong>
+      {href ? (
+        <a href={href} className="text-blue-600 hover:text-blue-800">
+          {data}
+        </a>
+      ) : (
+        <p className="text-gray-700">{data}</p>
+      )}
+    </div>
+  );
+}

--- a/src/pages/admin/candidates.tsx
+++ b/src/pages/admin/candidates.tsx
@@ -1,0 +1,55 @@
+import { Layout } from "~/component/layout/layout";
+import { AdminNavigationMenu } from "~/component/admin/adminNavigationMenu";
+import React from "react";
+import { appRouter } from "~/server/api/root";
+import { prisma } from "~/server/db";
+import superjson from "superjson";
+import type { InferGetServerSidePropsType } from "next";
+import Head from "next/head";
+import { CandidateResumePreview } from "~/component/candidate/resumePreview";
+import type { ParsedCandidate } from "~/pages/candidates";
+
+export default function Candidates({
+  unmoderatedCandidates,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const parsedCandidates: ParsedCandidate[] = superjson.parse(
+    unmoderatedCandidates
+  );
+
+  return (
+    <>
+      <Head>
+        <title>Job portal - Резюме кандидатів</title>
+      </Head>
+      <Layout>
+        <div className="container mx-auto my-4 flex flex-col items-center space-y-8">
+          <AdminNavigationMenu />
+          <hr className="w-full border-gray-300" />
+          {parsedCandidates.map((candidate) => {
+            return (
+              <CandidateResumePreview
+                candidate={candidate}
+                key={candidate.id}
+              />
+            );
+          })}
+        </div>
+      </Layout>
+    </>
+  );
+}
+
+export const getServerSideProps = async () => {
+  const context = appRouter.createCaller({ prisma });
+  const candidatesWithUnmoderatedResumes =
+    await context.admin.fetchUnmoderatedCandidates();
+  const serializedCandidates = superjson.stringify(
+    candidatesWithUnmoderatedResumes
+  );
+
+  return {
+    props: {
+      unmoderatedCandidates: serializedCandidates,
+    },
+  };
+};

--- a/src/pages/admin/employer.tsx
+++ b/src/pages/admin/employer.tsx
@@ -4,10 +4,15 @@ import React from "react";
 import { appRouter } from "~/server/api/root";
 import { prisma } from "~/server/db";
 import superjson from "superjson";
-import type { InferGetServerSidePropsType } from "next";
+import type {
+  GetServerSidePropsContext,
+  InferGetServerSidePropsType,
+} from "next";
 import Head from "next/head";
 import type { Vacancy } from "@prisma/client";
 import { VacancyPreview } from "~/component/employer/vacancyPreview";
+
+import { adminOnlyAccess } from "~/utils/admin/adminOnlyAccess";
 
 export default function Candidates({
   unmoderatedVacancies,
@@ -34,9 +39,22 @@ export default function Candidates({
   );
 }
 
-export const getServerSideProps = async () => {
-  const context = appRouter.createCaller({ prisma });
-  const unmoderatedVacancies = await context.admin.fetchUnmoderatedVacancies();
+export const getServerSideProps = async (
+  context: GetServerSidePropsContext
+) => {
+  const isAdmin = await adminOnlyAccess(context);
+
+  if (!isAdmin) {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  }
+
+  const caller = appRouter.createCaller({ prisma });
+  const unmoderatedVacancies = await caller.admin.fetchUnmoderatedVacancies();
   const serializedVacancies = superjson.stringify(unmoderatedVacancies);
 
   return {

--- a/src/pages/admin/employer.tsx
+++ b/src/pages/admin/employer.tsx
@@ -1,0 +1,47 @@
+import { Layout } from "~/component/layout/layout";
+import { AdminNavigationMenu } from "~/component/admin/adminNavigationMenu";
+import React from "react";
+import { appRouter } from "~/server/api/root";
+import { prisma } from "~/server/db";
+import superjson from "superjson";
+import type { InferGetServerSidePropsType } from "next";
+import Head from "next/head";
+import type { Vacancy } from "@prisma/client";
+import { VacancyPreview } from "~/component/employer/vacancyPreview";
+
+export default function Candidates({
+  unmoderatedVacancies,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const parseVacancies: Vacancy[] = superjson.parse(unmoderatedVacancies);
+
+  return (
+    <>
+      <Head>
+        <title>Job portal - Вакансії</title>
+      </Head>
+      <Layout>
+        <div className="container mx-auto my-4 flex flex-col items-center space-y-8">
+          <AdminNavigationMenu />
+          <hr className="w-full border-gray-300" />
+          {parseVacancies.map((vacancy) => {
+            return (
+              <VacancyPreview key={vacancy.questionnaireId} vacancy={vacancy} />
+            );
+          })}
+        </div>
+      </Layout>
+    </>
+  );
+}
+
+export const getServerSideProps = async () => {
+  const context = appRouter.createCaller({ prisma });
+  const unmoderatedVacancies = await context.admin.fetchUnmoderatedVacancies();
+  const serializedVacancies = superjson.stringify(unmoderatedVacancies);
+
+  return {
+    props: {
+      unmoderatedVacancies: serializedVacancies,
+    },
+  };
+};

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,0 +1,70 @@
+import { appRouter } from "~/server/api/root";
+import { prisma } from "~/server/db";
+import type {
+  GetServerSidePropsContext,
+  InferGetServerSidePropsType,
+} from "next";
+import { AUTHORIZATION_TOKEN_KEY } from "~/utils/auth/authorizationTokenKey";
+import { verifyToken } from "~/utils/auth/auth";
+import type { VerifyToken } from "~/utils/auth/withoutAuth";
+import { Layout } from "~/component/layout/layout";
+import { AdminNavigationMenu } from "~/component/admin/adminNavigationMenu";
+import React from "react";
+import Head from "next/head";
+
+export default function Admin({}: InferGetServerSidePropsType<
+  typeof getServerSideProps
+>) {
+  return (
+    <>
+      <Head>
+        <title>Job Portal – Hello admin!</title>
+      </Head>
+      <Layout>
+        <div className="container mx-auto my-4 flex flex-col items-center space-y-8">
+          <AdminNavigationMenu />
+          <hr className="w-full border-gray-300" />
+          <h1>Welcome to the club, buddy!</h1>
+        </div>
+      </Layout>
+    </>
+  );
+}
+
+export const getServerSideProps = async (
+  context: GetServerSidePropsContext
+) => {
+  const authToken = context.req.cookies[AUTHORIZATION_TOKEN_KEY] || "";
+  const verifiedToken = verifyToken(authToken) as VerifyToken | null;
+
+  if (!verifiedToken) {
+    return {
+      props: {},
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  }
+
+  const caller = appRouter.createCaller({ prisma });
+  const admin = await caller.admin.findAdminById({
+    adminId: verifiedToken.userId,
+  });
+
+  const isValidAdmin = admin && admin.userType === "ADMIN";
+
+  if (!isValidAdmin) {
+    return {
+      props: {},
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  }
+
+  return {
+    props: { admin },
+  };
+};

--- a/src/pages/api/candidate/updateModerationStatus.ts
+++ b/src/pages/api/candidate/updateModerationStatus.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { appRouter } from "~/server/api/root";
+import { prisma } from "~/server/db";
+import type { ModerationStatus } from "@prisma/client";
+
+export default async function updateProfile(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    res.status(405).json({ message: "Method not allowed" });
+  }
+
+  try {
+    const { moderationStatus, questionnaireId } = req.body as {
+      moderationStatus: ModerationStatus;
+      questionnaireId: string;
+    };
+
+    const caller = appRouter.createCaller({ prisma });
+    const updatedCandidateResume =
+      await caller.candidate.updateModerationStatus({
+        moderationStatus,
+        questionnaireId,
+      });
+
+    res.status(200).json({
+      message: "Successfully updated Questionnaire moderation status",
+      updatedCandidateResume,
+    });
+  } catch (error) {
+    res.status(400).json({ message: "Something went wrong", error });
+  }
+}

--- a/src/pages/api/employer/updateModerationStatus.ts
+++ b/src/pages/api/employer/updateModerationStatus.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { appRouter } from "~/server/api/root";
+import { prisma } from "~/server/db";
+import type { ModerationStatus } from "@prisma/client";
+
+export default async function updateModerationStatus(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    res.status(405).json({ message: "Method not allowed" });
+  }
+
+  try {
+    const { questionnaireId, moderationStatus } = req.body as {
+      questionnaireId: string;
+      moderationStatus: ModerationStatus;
+    };
+
+    const caller = appRouter.createCaller({ prisma });
+    const updatedVacancy = await caller.employer.updateModerationStatus({
+      moderationStatus,
+      questionnaireId,
+    });
+
+    res.status(200).json({
+      message: "Moderation status successfully updated",
+      updatedVacancy,
+    });
+  } catch (error) {
+    res.status(400).json({ message: "Something went wrong", error });
+  }
+}

--- a/src/pages/candidate/[candidate].tsx
+++ b/src/pages/candidate/[candidate].tsx
@@ -7,27 +7,25 @@ import type { User, Candidate, Questionnaire, Resume } from "@prisma/client";
 import Head from "next/head";
 import React, { useContext } from "react";
 import { AuthContext } from "~/utils/auth/authContext";
-import { SelectModerationStatus } from "~/component/admin/selectModerationStatus";
 import { renderQuestionnaireInfo } from "~/component/questionnaire/renderQuestionnaireInfo";
 import { renderQuestionnaireDetail } from "~/component/questionnaire/renderQuestionnaireDetail";
+import { ModerateCandidate } from "~/component/admin/moderation/moderateCandidate";
+
+export type ParsedCandidate =
+  | (User & {
+      candidate:
+        | (Candidate & {
+            questionnaires: (Questionnaire & { resume: Resume | null }) | null;
+          })
+        | null;
+    })
+  | null;
 
 export default function Candidate({
   candidate,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const authorizedUser = useContext(AuthContext);
   const isUserAdmin = authorizedUser?.userType === "ADMIN";
-
-  type ParsedCandidate =
-    | (User & {
-        candidate:
-          | (Candidate & {
-              questionnaires:
-                | (Questionnaire & { resume: Resume | null })
-                | null;
-            })
-          | null;
-      })
-    | null;
 
   const parsedCandidate: ParsedCandidate = superjson.parse(candidate);
   const candidatesResume = parsedCandidate?.candidate?.questionnaires?.resume;
@@ -107,22 +105,7 @@ export default function Candidate({
               parsedCandidate?.telegramLink
             )}
             {isUserAdmin && (
-              <>
-                <hr className="w-full border-gray-300" />
-                <strong className="py-4 text-lg font-semibold">
-                  Статус модерації:
-                </strong>
-                <SelectModerationStatus
-                  moderationStatus={
-                    parsedCandidate?.candidate?.questionnaires?.resume
-                      ?.moderationStatus || "PENDING"
-                  }
-                  questionnaireId={
-                    parsedCandidate?.candidate?.questionnaires
-                      ?.questionnaireId || ""
-                  }
-                />
-              </>
+              <ModerateCandidate candidateData={parsedCandidate} />
             )}
           </div>
         </div>

--- a/src/pages/candidate/[candidate].tsx
+++ b/src/pages/candidate/[candidate].tsx
@@ -5,10 +5,16 @@ import superjson from "superjson";
 import type { GetStaticPaths, InferGetStaticPropsType } from "next";
 import type { User, Candidate, Questionnaire, Resume } from "@prisma/client";
 import Head from "next/head";
+import React, { useContext } from "react";
+import { AuthContext } from "~/utils/auth/authContext";
+import { SelectModerationStatus } from "~/component/admin/selectModerationStatus";
 
 export default function Candidate({
   candidate,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
+  const authorizedUser = useContext(AuthContext);
+  const isUserAdmin = authorizedUser?.userType === "ADMIN";
+
   type ParsedCandidate =
     | User & {
         candidate:
@@ -124,6 +130,23 @@ export default function Candidate({
               parsedCandidate.telegramLink,
               parsedCandidate.telegramLink
             )}
+            {isUserAdmin && (
+              <>
+                <hr className="w-full border-gray-300" />
+                <strong className="py-4 text-lg font-semibold">
+                  Статус модерації:
+                </strong>
+                <SelectModerationStatus
+                  moderationStatus={
+                    parsedCandidate.candidate.questionnaires.resume
+                      .moderationStatus
+                  }
+                  questionnaireId={
+                    parsedCandidate.candidate.questionnaires.questionnaireId
+                  }
+                />
+              </>
+            )}
           </div>
         </div>
       </Layout>
@@ -162,5 +185,6 @@ export const getStaticProps = async ({ params }: StaticPaths) => {
     props: {
       candidate: serializedCandidate,
     },
+    revalidate: 20,
   };
 };

--- a/src/pages/candidate/[candidate].tsx
+++ b/src/pages/candidate/[candidate].tsx
@@ -8,6 +8,8 @@ import Head from "next/head";
 import React, { useContext } from "react";
 import { AuthContext } from "~/utils/auth/authContext";
 import { SelectModerationStatus } from "~/component/admin/selectModerationStatus";
+import { renderQuestionnaireInfo } from "~/component/questionnaire/renderQuestionnaireInfo";
+import { renderQuestionnaireDetail } from "~/component/questionnaire/renderQuestionnaireDetail";
 
 export default function Candidate({
   candidate,
@@ -30,39 +32,6 @@ export default function Candidate({
   const parsedCandidate: ParsedCandidate = superjson.parse(candidate);
   const candidatesResume = parsedCandidate?.candidate?.questionnaires?.resume;
 
-  function renderCandidateResumeInfo(
-    title: string,
-    data: string | null | undefined
-  ) {
-    if (!data) return null;
-    return (
-      <div className="mb-4">
-        <strong className="text-lg font-semibold">{title}:</strong>
-        <p className="mt-2 text-gray-700">{data}</p>
-      </div>
-    );
-  }
-
-  function renderCandidateContactInfo(
-    title: string,
-    data: string | null | undefined,
-    href?: string | null
-  ) {
-    if (!data) return null;
-    return (
-      <div className="mb-4 flex items-center gap-2">
-        <strong className="text-lg font-semibold">{title}:</strong>
-        {href ? (
-          <a href={href} className="text-blue-600 hover:text-blue-800">
-            {data}
-          </a>
-        ) : (
-          <p className="text-gray-700">{data}</p>
-        )}
-      </div>
-    );
-  }
-
   return (
     <>
       <Head>
@@ -80,59 +49,59 @@ export default function Candidate({
             <h3 className="mb-4 text-xl font-medium">
               {candidatesResume?.specialty}
             </h3>
-            {renderCandidateResumeInfo(
+            {renderQuestionnaireDetail(
               "Досвід роботи",
               candidatesResume?.workExperience
             )}
-            {renderCandidateResumeInfo("Навички", candidatesResume?.skills)}
-            {renderCandidateResumeInfo("Освіта", candidatesResume?.education)}
-            {renderCandidateResumeInfo(
+            {renderQuestionnaireDetail("Навички", candidatesResume?.skills)}
+            {renderQuestionnaireDetail("Освіта", candidatesResume?.education)}
+            {renderQuestionnaireDetail(
               "Іноземні мови",
               candidatesResume?.foreignLanguages
             )}
-            {renderCandidateResumeInfo("Інтереси", candidatesResume?.interests)}
-            {renderCandidateResumeInfo(
+            {renderQuestionnaireDetail("Інтереси", candidatesResume?.interests)}
+            {renderQuestionnaireDetail(
               "Досягнення",
               candidatesResume?.achievements
             )}
-            {renderCandidateResumeInfo(
+            {renderQuestionnaireDetail(
               "Досвід роботи",
               candidatesResume?.workExperience
             )}
           </div>
           <div className="w-1/3 rounded-lg border bg-white p-6 shadow-lg">
             <h3 className="mb-4 text-xl font-medium">Контактна інформація</h3>
-            {renderCandidateContactInfo(
+            {renderQuestionnaireInfo(
               "Бажана зарплата",
               candidatesResume?.desiredSalary
             )}
-            {renderCandidateContactInfo(
+            {renderQuestionnaireInfo(
               "Бажана зайнятість",
               candidatesResume?.employment
             )}
-            {renderCandidateContactInfo(
+            {renderQuestionnaireInfo(
               "Номере телефону",
               parsedCandidate?.phoneNumber,
               parsedCandidate?.phoneNumber
                 ? `tel:${parsedCandidate.phoneNumber}`
                 : ""
             )}
-            {renderCandidateContactInfo(
+            {renderQuestionnaireInfo(
               "Email",
               parsedCandidate?.email,
               parsedCandidate?.email ? `mailto:${parsedCandidate.email}` : ""
             )}
-            {renderCandidateContactInfo(
+            {renderQuestionnaireInfo(
               "Linkedin",
               parsedCandidate?.linkedinLink,
               parsedCandidate?.linkedinLink
             )}
-            {renderCandidateContactInfo(
+            {renderQuestionnaireInfo(
               "Github",
               parsedCandidate?.githubLink,
               parsedCandidate?.githubLink
             )}
-            {renderCandidateContactInfo(
+            {renderQuestionnaireInfo(
               "Telegram",
               parsedCandidate?.telegramLink,
               parsedCandidate?.telegramLink

--- a/src/pages/candidates/index.tsx
+++ b/src/pages/candidates/index.tsx
@@ -5,20 +5,20 @@ import superjson from "superjson";
 import Head from "next/head";
 import type { InferGetStaticPropsType } from "next";
 import type { User, Candidate, Questionnaire, Resume } from "@prisma/client";
-import Link from "next/link";
+import { CandidateResumePreview } from "~/component/candidate/resumePreview";
+
+export type ParsedCandidate = User & {
+  candidate:
+    | (Candidate & {
+        questionnaires: (Questionnaire & { resume: Resume | null }) | null;
+      })
+    | null;
+};
 
 export default function Candidates({
   candidates,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  type ParsedCandidates = (User & {
-    candidate:
-      | (Candidate & {
-          questionnaires: (Questionnaire & { resume: Resume | null }) | null;
-        })
-      | null;
-  })[];
-
-  const parsedCandidates: ParsedCandidates = superjson.parse(candidates);
+  const parsedCandidates: ParsedCandidate[] = superjson.parse(candidates);
 
   return (
     <>
@@ -38,51 +38,10 @@ export default function Candidates({
           )}
           <div className="grid grid-cols-1 gap-4">
             {parsedCandidates.map((candidate) => (
-              <div
-                className="rounded-md border border-gray-300 p-4"
+              <CandidateResumePreview
                 key={candidate.id}
-              >
-                <Link
-                  href={`/candidate/${candidate.id}`}
-                  className="mb-3 flex items-center"
-                >
-                  <div>
-                    <div className="font-bold text-blue-600  hover:text-blue-800">
-                      {candidate.firstName} {candidate.lastName}
-                    </div>
-                    <div className="text-sm text-gray-500">
-                      {candidate.candidate?.questionnaires?.resume?.specialty}
-                    </div>
-                  </div>
-                </Link>
-                <div className="mb-2">
-                  <strong>Work Experience:</strong>{" "}
-                  {candidate.candidate?.questionnaires?.resume?.workExperience}
-                </div>
-                <div className="mb-2">
-                  <strong>Skills:</strong>{" "}
-                  {candidate.candidate?.questionnaires?.resume?.skills}
-                </div>
-                <div className="mb-2">
-                  <strong>Education:</strong>{" "}
-                  {candidate.candidate?.questionnaires?.resume?.education}
-                </div>
-                <div className="mb-2">
-                  <strong>Foreign Languages:</strong>{" "}
-                  {
-                    candidate.candidate?.questionnaires?.resume
-                      ?.foreignLanguages
-                  }
-                </div>
-                <div className="mb-2">
-                  <strong>Interests:</strong>{" "}
-                  {candidate.candidate?.questionnaires?.resume?.interests}
-                </div>
-                <div className="mb-2">
-                  <strong>Achievements:</strong>{" "}
-                  {candidate.candidate?.questionnaires?.resume?.achievements}
-                </div>
-              </div>
+                candidate={candidate}
+              />
             ))}
           </div>
         </div>

--- a/src/pages/job/[job].tsx
+++ b/src/pages/job/[job].tsx
@@ -5,21 +5,26 @@ import type { GetStaticPaths, InferGetStaticPropsType } from "next";
 import superjson from "superjson";
 import type { User, Employer, Vacancy } from "@prisma/client";
 import Head from "next/head";
-import React from "react";
+import React, { useContext } from "react";
 import { format } from "date-fns";
 import { renderQuestionnaireDetail } from "~/component/questionnaire/renderQuestionnaireDetail";
 import { renderQuestionnaireInfo } from "~/component/questionnaire/renderQuestionnaireInfo";
+import { AuthContext } from "~/utils/auth/authContext";
+import { ModerateJob } from "~/component/admin/moderation/moderateJob";
+
+export type JobInformation = {
+  vacancy: Vacancy | null;
+  employer: (User & { employer: Employer | null }) | null;
+};
 
 export default function Job({
   jobInformation,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  type JobInformation = {
-    vacancy: Vacancy | null;
-    employer: (User & { employer: Employer | null }) | null;
-  };
+  const authContext = useContext(AuthContext);
+  const isAdmin = authContext?.userType === "ADMIN";
 
   const parsedJobInformation: JobInformation = superjson.parse(jobInformation);
-  console.log(parsedJobInformation);
+
   return (
     <>
       <Head>
@@ -95,6 +100,7 @@ export default function Job({
               parsedJobInformation.employer?.linkedinLink,
               parsedJobInformation.employer?.linkedinLink
             )}
+            {isAdmin && <ModerateJob jobInfo={parsedJobInformation} />}
           </div>
         </div>
       </Layout>

--- a/src/pages/job/[job].tsx
+++ b/src/pages/job/[job].tsx
@@ -1,0 +1,93 @@
+import { Layout } from "~/component/layout/layout";
+import { appRouter } from "~/server/api/root";
+import { prisma } from "~/server/db";
+import type { GetStaticPaths, InferGetStaticPropsType } from "next";
+import superjson from "superjson";
+import type { Vacancy } from "@prisma/client";
+import Head from "next/head";
+import React from "react";
+import { format } from "date-fns";
+
+export default function Job({
+  job,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  const parsedJob: Vacancy = superjson.parse(job);
+
+  function renderJobDetail(title: string, data: string | null | undefined) {
+    if (!data) return null;
+    return (
+      <div className="mb-4">
+        <strong className="text-lg font-semibold">{title}:</strong>
+        <p className="mt-2 text-gray-700">{data}</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Job Portal – {parsedJob.specialty}</title>
+      </Head>
+      <Layout>
+        <div className="container mx-auto mt-6">
+          <div className="rounded-lg border bg-white p-6 shadow-lg">
+            <h2 className="mb-6 text-2xl font-bold">{parsedJob.specialty}</h2>
+            {renderJobDetail(
+              "Salary",
+              parsedJob.salary && `$${parsedJob.salary}`
+            )}
+            {renderJobDetail("Обов'язки", parsedJob.duties)}
+            {renderJobDetail("Вимоги", parsedJob.requirements)}
+            {renderJobDetail("Умови", parsedJob.conditions)}
+            {renderJobDetail("Графік роботи", parsedJob.workSchedule)}
+            {renderJobDetail("Тип зайнятості", parsedJob.employment)}
+            <div className="mb-4">
+              <strong className="text-lg font-semibold">
+                Дата публікації:
+              </strong>
+              <p className="mt-2 text-gray-700">
+                {format(parsedJob?.dateOfPublication, "d MMMM yyyy, HH:mm")}
+              </p>
+            </div>
+          </div>
+        </div>
+      </Layout>
+    </>
+  );
+}
+
+type StaticPath = {
+  params: {
+    job: string;
+  };
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const caller = appRouter.createCaller({ prisma });
+  const jobs = await caller.employer.fetchAllVacancies();
+
+  const paths: StaticPath[] = jobs.map((job) => ({
+    params: { job: job.questionnaireId },
+  }));
+
+  return {
+    paths,
+    fallback: false,
+  };
+};
+
+export const getStaticProps = async ({ params }: StaticPath) => {
+  const caller = appRouter.createCaller({ prisma });
+  const job = await caller.employer.findVacancyById({
+    vacancyId: params.job,
+  });
+
+  const serializedJob = superjson.stringify(job);
+
+  return {
+    props: {
+      job: serializedJob,
+    },
+    revalidate: 20,
+  };
+};

--- a/src/pages/jobs/index.tsx
+++ b/src/pages/jobs/index.tsx
@@ -1,9 +1,53 @@
 import { Layout } from "~/component/layout/layout";
+import { appRouter } from "~/server/api/root";
+import { prisma } from "~/server/db";
+import superjson from "superjson";
+import Head from "next/head";
+import type { InferGetStaticPropsType } from "next";
+import type { Vacancy } from "@prisma/client";
+import { VacancyPreview } from "~/component/employer/vacancyPreview";
 
-export default function Index() {
+export default function Candidates({
+  vacancies,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  const parsedVacancies: Vacancy[] = superjson.parse(vacancies);
+
   return (
     <>
-      <Layout>jobs page</Layout>
+      <Head>
+        <title>Job Portal – Список доступних кандидатів</title>
+      </Head>
+      <Layout>
+        <div className="container mx-auto px-4">
+          {parsedVacancies.length ? (
+            <h2 className="py-3 text-2xl font-bold">
+              Список доступних кандидатів
+            </h2>
+          ) : (
+            <h2 className="py-3 text-2xl font-bold">
+              Наразі немає доступних вакансій
+            </h2>
+          )}
+          <div className="grid grid-cols-1 gap-4">
+            {parsedVacancies.map((vacancy) => (
+              <VacancyPreview key={vacancy.questionnaireId} vacancy={vacancy} />
+            ))}
+          </div>
+        </div>
+      </Layout>
     </>
   );
 }
+
+export const getStaticProps = async () => {
+  const caller = appRouter.createCaller({ prisma });
+  const vacancies = await caller.employer.fetchAvailableVacancies();
+  const serializedVacancies = superjson.stringify(vacancies);
+
+  return {
+    props: {
+      vacancies: serializedVacancies,
+    },
+    revalidate: 20,
+  };
+};

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -3,6 +3,7 @@ import { authRouter } from "~/server/api/routers/auth";
 import { candidateAccountRouter } from "~/server/api/routers/candidate";
 import { employerAccountRouter } from "~/server/api/routers/employer";
 import { userRouter } from "~/server/api/routers/user";
+import { adminRouter } from "~/server/api/routers/admin";
 
 /**
  * This is the primary router for your server.
@@ -14,6 +15,7 @@ export const appRouter = createTRPCRouter({
   user: userRouter,
   candidate: candidateAccountRouter,
   employer: employerAccountRouter,
+  admin: adminRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -1,0 +1,15 @@
+import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import { z } from "zod";
+import { prisma } from "~/server/db";
+
+export const adminRouter = createTRPCRouter({
+  findAdminById: publicProcedure
+    .input(z.object({ adminId: z.string() }))
+    .query(async ({ input }) => {
+      const { adminId } = input;
+      return prisma.user.findUnique({ where: { id: adminId } });
+    }),
+  unmoderatedResumes: publicProcedure.query(async () => {
+    return prisma.resume.findMany({ where: { moderationStatus: "PENDING" } });
+  }),
+});

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -23,4 +23,9 @@ export const adminRouter = createTRPCRouter({
       },
     });
   }),
+  fetchUnmoderatedVacancies: publicProcedure.query(async () => {
+    return prisma.vacancy.findMany({
+      where: { moderationStatus: "PENDING" },
+    });
+  }),
 });

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -9,7 +9,18 @@ export const adminRouter = createTRPCRouter({
       const { adminId } = input;
       return prisma.user.findUnique({ where: { id: adminId } });
     }),
-  unmoderatedResumes: publicProcedure.query(async () => {
-    return prisma.resume.findMany({ where: { moderationStatus: "PENDING" } });
+  fetchUnmoderatedCandidates: publicProcedure.query(async () => {
+    return prisma.user.findMany({
+      include: {
+        candidate: {
+          include: { questionnaires: { include: { resume: true } } },
+        },
+      },
+      where: {
+        candidate: {
+          questionnaires: { resume: { moderationStatus: "PENDING" } },
+        },
+      },
+    });
   }),
 });

--- a/src/server/api/routers/candidate.ts
+++ b/src/server/api/routers/candidate.ts
@@ -65,6 +65,21 @@ export const candidateAccountRouter = createTRPCRouter({
     return prisma.user.findMany({
       where: {
         userType: "CANDIDATE",
+        candidate: {
+          questionnaires: { resume: { moderationStatus: "ACCEPTED" } },
+        },
+      },
+      include: {
+        candidate: {
+          include: { questionnaires: { include: { resume: true } } },
+        },
+      },
+    });
+  }),
+  fetchAllCandidates: publicProcedure.query(async () => {
+    return prisma.user.findMany({
+      where: {
+        userType: "CANDIDATE",
       },
       include: {
         candidate: {

--- a/src/server/api/routers/candidate.ts
+++ b/src/server/api/routers/candidate.ts
@@ -1,6 +1,7 @@
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 import { z } from "zod";
 import { prisma } from "~/server/db";
+import { ModerationStatus } from "@prisma/client";
 
 export const candidateAccountRouter = createTRPCRouter({
   findCandidateById: publicProcedure
@@ -64,9 +65,6 @@ export const candidateAccountRouter = createTRPCRouter({
     return prisma.user.findMany({
       where: {
         userType: "CANDIDATE",
-        candidate: {
-          questionnaires: { resume: { moderationStatus: "ACCEPTED" } },
-        },
       },
       include: {
         candidate: {
@@ -75,4 +73,20 @@ export const candidateAccountRouter = createTRPCRouter({
       },
     });
   }),
+  updateModerationStatus: publicProcedure
+    .input(
+      z.object({
+        moderationStatus: z.nativeEnum(ModerationStatus),
+        questionnaireId: z.string(),
+      })
+    )
+    .query(async ({ input }) => {
+      const { moderationStatus, questionnaireId } = input;
+      return prisma.resume.update({
+        where: { questionnaireId },
+        data: {
+          moderationStatus,
+        },
+      });
+    }),
 });

--- a/src/server/api/routers/employer.ts
+++ b/src/server/api/routers/employer.ts
@@ -1,6 +1,7 @@
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 import { z } from "zod";
 import { prisma } from "~/server/db";
+import { ModerationStatus } from "@prisma/client";
 
 export const employerAccountRouter = createTRPCRouter({
   findEmployeeById: publicProcedure
@@ -152,5 +153,19 @@ export const employerAccountRouter = createTRPCRouter({
         vacancy,
         employer,
       };
+    }),
+  updateModerationStatus: publicProcedure
+    .input(
+      z.object({
+        moderationStatus: z.nativeEnum(ModerationStatus),
+        questionnaireId: z.string(),
+      })
+    )
+    .query(async ({ input }) => {
+      const { moderationStatus, questionnaireId } = input;
+      return prisma.vacancy.update({
+        where: { questionnaireId },
+        data: { moderationStatus },
+      });
     }),
 });

--- a/src/server/api/routers/employer.ts
+++ b/src/server/api/routers/employer.ts
@@ -133,12 +133,24 @@ export const employerAccountRouter = createTRPCRouter({
   fetchAllVacancies: publicProcedure.query(async () => {
     return prisma.vacancy.findMany();
   }),
-  findVacancyById: publicProcedure
+  informationAboutVacancy: publicProcedure
     .input(z.object({ vacancyId: z.string() }))
     .query(async ({ input }) => {
       const { vacancyId } = input;
-      return prisma.vacancy.findUnique({
+      const vacancy = await prisma.vacancy.findUnique({
         where: { questionnaireId: vacancyId },
       });
+
+      const employer = await prisma.user.findUnique({
+        where: { id: vacancy?.employerId },
+        include: {
+          employer: true,
+        },
+      });
+
+      return {
+        vacancy,
+        employer,
+      };
     }),
 });

--- a/src/server/api/routers/employer.ts
+++ b/src/server/api/routers/employer.ts
@@ -130,4 +130,15 @@ export const employerAccountRouter = createTRPCRouter({
       where: { moderationStatus: "ACCEPTED" },
     });
   }),
+  fetchAllVacancies: publicProcedure.query(async () => {
+    return prisma.vacancy.findMany();
+  }),
+  findVacancyById: publicProcedure
+    .input(z.object({ vacancyId: z.string() }))
+    .query(async ({ input }) => {
+      const { vacancyId } = input;
+      return prisma.vacancy.findUnique({
+        where: { questionnaireId: vacancyId },
+      });
+    }),
 });

--- a/src/server/api/routers/employer.ts
+++ b/src/server/api/routers/employer.ts
@@ -125,4 +125,9 @@ export const employerAccountRouter = createTRPCRouter({
         },
       });
     }),
+  fetchAvailableVacancies: publicProcedure.query(async () => {
+    return prisma.vacancy.findMany({
+      where: { moderationStatus: "ACCEPTED" },
+    });
+  }),
 });

--- a/src/utils/admin/adminOnlyAccess.tsx
+++ b/src/utils/admin/adminOnlyAccess.tsx
@@ -1,0 +1,25 @@
+import type { GetServerSidePropsContext } from "next";
+import { AUTHORIZATION_TOKEN_KEY } from "~/utils/auth/authorizationTokenKey";
+import { verifyToken } from "~/utils/auth/auth";
+import type { VerifyToken } from "~/utils/auth/withoutAuth";
+import { appRouter } from "~/server/api/root";
+import { prisma } from "~/server/db";
+
+export async function adminOnlyAccess(
+  context: GetServerSidePropsContext
+): Promise<boolean> {
+  const authToken = context.req.cookies[AUTHORIZATION_TOKEN_KEY] || "";
+  const verifiedToken = verifyToken(authToken) as VerifyToken | null;
+
+  if (!verifiedToken) {
+    return false;
+  }
+
+  const caller = appRouter.createCaller({ prisma });
+  const admin = await caller.admin.findAdminById({
+    adminId: verifiedToken.userId,
+  });
+  const isValidAdmin = admin && admin.userType === "ADMIN";
+
+  return !!isValidAdmin;
+}


### PR DESCRIPTION
In this pull request, I have implemented an admin page with the functionality to moderate both vacancies and resumes.

The new features introduced include:

Admin Page: Created a new page accessible only by users with admin privileges. This dedicated space allows administrators to manage the moderation process more effectively.

Vacancy Moderation: Admins can now review and moderate posted vacancies. They have the power to alter the moderation status between 'PENDING', 'ACCEPTED', and 'REJECTED'. This ensures that only appropriate and legitimate vacancies are made visible on our platform.

Resume Moderation: Similar to vacancy moderation, this feature allows admins to review and change the moderation status of uploaded resumes. This ensures the quality of resumes presented on our platform.

The changes aim to provide a better level of control over the content shared on the platform, ensuring that it meets our community guidelines and standards. Detailed tests have been conducted to confirm the functionality and reliability of these new features.