### PR TITLE
Add Moderation Status Label for Candidates and Employer Vacancies

### DIFF
--- a/src/component/layout/elements/candidateModerationStatus.tsx
+++ b/src/component/layout/elements/candidateModerationStatus.tsx
@@ -1,0 +1,37 @@
+import type { ModerationStatus } from "@prisma/client";
+import { useContext, useEffect, useState } from "react";
+import { api } from "~/utils/api";
+import { AuthContext } from "~/utils/auth/authContext";
+
+export function CandidateModerationStatus() {
+  const authContext = useContext(AuthContext);
+  const [moderationStatus, setModerationStatus] =
+    useState<ModerationStatus>("PENDING");
+
+  const { data: candidatesQuestionnaire } =
+    api.candidate.findQuestionnaireByCandidateId.useQuery({
+      candidateId: authContext?.id || "",
+    });
+
+  useEffect(() => {
+    if (candidatesQuestionnaire) {
+      setModerationStatus(candidatesQuestionnaire.moderationStatus);
+    }
+  }, [candidatesQuestionnaire]);
+
+  const moderationStyle = {
+    ACCEPTED: "bg-green-50 text-green-700 ring-green-600/20",
+    PENDING: "bg-yellow-50 text-yellow-800 ring-yellow-600/20",
+    REJECTED: "bg-red-50 text-red-700 ring-red-600/10",
+  };
+
+  return (
+    <div>
+      <span
+        className={`inline-flex items-center rounded-md px-2 py-1 text-sm font-medium ring-1 ring-inset ${moderationStyle[moderationStatus]}`}
+      >
+        {moderationStatus}
+      </span>
+    </div>
+  );
+}

--- a/src/component/layout/elements/header.tsx
+++ b/src/component/layout/elements/header.tsx
@@ -3,6 +3,9 @@ import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { ProfileDropdownMenu } from "~/component/layout/elements/profileDropdownMenu";
+import { useContext } from "react";
+import { AuthContext } from "~/utils/auth/authContext";
+import { CandidateModerationStatus } from "~/component/layout/elements/candidateModerationStatus";
 
 const navigation: { name: string; href: string }[] = [
   { name: "Пропозиції", href: "/my/offers" },
@@ -15,6 +18,8 @@ export function classNames(...classes: { toString: () => string }[]) {
 
 export function Header() {
   const router = useRouter();
+  const authContext = useContext(AuthContext);
+  const isCandidate = authContext?.userType === "CANDIDATE";
 
   const isActivePage = (currentPage: string) => currentPage === router.pathname;
 
@@ -67,6 +72,7 @@ export function Header() {
                     </div>
                   </div>
                 </div>
+                {isCandidate && <CandidateModerationStatus />}
                 <ProfileDropdownMenu />
               </div>
             </div>

--- a/src/component/layout/elements/header.tsx
+++ b/src/component/layout/elements/header.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/router";
 import { ProfileDropdownMenu } from "~/component/layout/elements/profileDropdownMenu";
 import { useContext } from "react";
 import { AuthContext } from "~/utils/auth/authContext";
-import { CandidateModerationStatus } from "~/component/layout/elements/candidateModerationStatus";
+import { CandidateModerationStatus } from "~/component/layout/elements/moderation/candidateModerationStatus";
 
 const navigation: { name: string; href: string }[] = [
   { name: "Пропозиції", href: "/my/offers" },

--- a/src/component/layout/elements/moderation/candidateModerationStatus.tsx
+++ b/src/component/layout/elements/moderation/candidateModerationStatus.tsx
@@ -2,6 +2,7 @@ import type { ModerationStatus } from "@prisma/client";
 import { useContext, useEffect, useState } from "react";
 import { api } from "~/utils/api";
 import { AuthContext } from "~/utils/auth/authContext";
+import { ModerationLabel } from "~/component/layout/elements/moderation/moderationLabel";
 
 export function CandidateModerationStatus() {
   const authContext = useContext(AuthContext);
@@ -19,19 +20,5 @@ export function CandidateModerationStatus() {
     }
   }, [candidatesQuestionnaire]);
 
-  const moderationStyle = {
-    ACCEPTED: "bg-green-50 text-green-700 ring-green-600/20",
-    PENDING: "bg-yellow-50 text-yellow-800 ring-yellow-600/20",
-    REJECTED: "bg-red-50 text-red-700 ring-red-600/10",
-  };
-
-  return (
-    <div>
-      <span
-        className={`inline-flex items-center rounded-md px-2 py-1 text-sm font-medium ring-1 ring-inset ${moderationStyle[moderationStatus]}`}
-      >
-        {moderationStatus}
-      </span>
-    </div>
-  );
+  return <ModerationLabel moderationStatus={moderationStatus} />;
 }

--- a/src/component/layout/elements/moderation/moderationLabel.tsx
+++ b/src/component/layout/elements/moderation/moderationLabel.tsx
@@ -1,0 +1,23 @@
+import type { ModerationStatus } from "@prisma/client";
+
+export function ModerationLabel({
+  moderationStatus,
+}: {
+  moderationStatus: ModerationStatus;
+}) {
+  const moderationStyle = {
+    ACCEPTED: "bg-green-50 text-green-700 ring-green-600/20",
+    PENDING: "bg-yellow-50 text-yellow-800 ring-yellow-600/20",
+    REJECTED: "bg-red-50 text-red-700 ring-red-600/10",
+  };
+
+  return (
+    <div>
+      <span
+        className={`inline-flex items-center rounded-md px-2 py-1 text-sm font-medium ring-1 ring-inset ${moderationStyle[moderationStatus]}`}
+      >
+        {moderationStatus}
+      </span>
+    </div>
+  );
+}

--- a/src/pages/home/vacancies.tsx
+++ b/src/pages/home/vacancies.tsx
@@ -10,6 +10,7 @@ import { getEmployerData } from "~/utils/getEmployerData/getEmployerData";
 import type { EmployerData } from "~/pages/home/profile";
 import superjson from "superjson";
 import Link from "next/link";
+import { ModerationLabel } from "~/component/layout/elements/moderation/moderationLabel";
 
 export default function Vacancies({
   employer,
@@ -43,6 +44,13 @@ export default function Vacancies({
                           {questionnaire.vacancy.specialty}
                         </Link>
                       </h2>
+                      <div className="mr-3">
+                        <ModerationLabel
+                          moderationStatus={
+                            questionnaire.vacancy.moderationStatus
+                          }
+                        />
+                      </div>
                       {questionnaire.vacancy.salary && (
                         <p className="font-semibold text-gray-700">
                           ${questionnaire.vacancy.salary}

--- a/src/server/api/routers/candidate.ts
+++ b/src/server/api/routers/candidate.ts
@@ -17,6 +17,14 @@ export const candidateAccountRouter = createTRPCRouter({
         },
       });
     }),
+  findQuestionnaireByCandidateId: publicProcedure
+    .input(z.object({ candidateId: z.string() }))
+    .query(({ input }) => {
+      const { candidateId } = input;
+      return prisma.resume.findUnique({
+        where: { candidateId },
+      });
+    }),
   updateCandidateResume: publicProcedure
     .input(
       z.object({


### PR DESCRIPTION
In this pull request, I have introduced a new feature that enhances the user interface and overall usability of our application. Specifically, we have added a moderation status label for both candidates and employer vacancies. 

Changes include:

1. **Candidate Moderation Label**: Now, each candidate's profile will display a moderation status label. This label will help administrators easily identify the moderation status of each candidate, increasing the efficiency of the moderation process.

2. **Employer Vacancy Moderation Label**: Similarly, we have added a moderation status label to each vacancy posted by employers. This will facilitate the moderation process of vacancies, ensuring only approved and suitable listings are visible to potential candidates.
